### PR TITLE
Updated to 42.0 (jammy)

### DIFF
--- a/nautilus-restore-typeahead.patch
+++ b/nautilus-restore-typeahead.patch
@@ -1,8 +1,8 @@
-Index: nautilus-40.2/data/org.gnome.nautilus.gschema.xml
+Index: nautilus-42.0/data/org.gnome.nautilus.gschema.xml
 ===================================================================
---- nautilus-40.2.orig/data/org.gnome.nautilus.gschema.xml
-+++ nautilus-40.2/data/org.gnome.nautilus.gschema.xml
-@@ -186,6 +186,11 @@
+--- nautilus-42.0.orig/data/org.gnome.nautilus.gschema.xml
++++ nautilus-42.0/data/org.gnome.nautilus.gschema.xml
+@@ -188,6 +188,11 @@
        <summary>What viewer should be used when searching</summary>
        <description>When searching Nautilus will switch to the type of view in this setting.</description>
      </key>
@@ -14,11 +14,11 @@ Index: nautilus-40.2/data/org.gnome.nautilus.gschema.xml
      <key type="b" name="open-folder-on-dnd-hover">
        <default>true</default>
        <summary>Whether to open the hovered folder after a timeout when drag and drop operation</summary>
-Index: nautilus-40.2/src/nautilus-global-preferences.h
+Index: nautilus-42.0/src/nautilus-global-preferences.h
 ===================================================================
---- nautilus-40.2.orig/src/nautilus-global-preferences.h
-+++ nautilus-40.2/src/nautilus-global-preferences.h
-@@ -127,6 +127,9 @@ typedef enum
+--- nautilus-42.0.orig/src/nautilus-global-preferences.h
++++ nautilus-42.0/src/nautilus-global-preferences.h
+@@ -128,6 +128,9 @@ typedef enum
  /* Recent files */
  #define NAUTILUS_PREFERENCES_RECENT_FILES_ENABLED          "remember-recent-files"
  
@@ -28,11 +28,11 @@ Index: nautilus-40.2/src/nautilus-global-preferences.h
  /* Default view when searching */
  #define NAUTILUS_PREFERENCES_SEARCH_VIEW "search-view"
  
-Index: nautilus-40.2/src/nautilus-list-view.c
+Index: nautilus-42.0/src/nautilus-list-view.c
 ===================================================================
---- nautilus-40.2.orig/src/nautilus-list-view.c
-+++ nautilus-40.2/src/nautilus-list-view.c
-@@ -3134,6 +3134,7 @@ nautilus_list_view_set_selection (Nautil
+--- nautilus-42.0.orig/src/nautilus-list-view.c
++++ nautilus-42.0/src/nautilus-list-view.c
+@@ -3122,6 +3122,7 @@ nautilus_list_view_set_selection (NautilusFilesView *view,
      gboolean cursor_is_set_on_selection = FALSE;
      GList *iters, *l;
      NautilusFile *file;
@@ -40,7 +40,7 @@ Index: nautilus-40.2/src/nautilus-list-view.c
  
      list_view = NAUTILUS_LIST_VIEW (view);
      model = list_view->details->model;
-@@ -3165,10 +3166,22 @@ nautilus_list_view_set_selection (Nautil
+@@ -3153,10 +3154,22 @@ nautilus_list_view_set_selection (NautilusFilesView *view,
  
              gtk_tree_selection_select_iter (tree_selection,
                                              (GtkTreeIter *) l->data);
@@ -63,7 +63,7 @@ Index: nautilus-40.2/src/nautilus-list-view.c
      g_signal_handlers_unblock_by_func (tree_selection, list_selection_changed_callback, view);
      nautilus_files_view_notify_selection_changed (view);
  }
-@@ -4189,3 +4202,9 @@ nautilus_list_view_new (NautilusWindowSl
+@@ -4161,3 +4174,9 @@ nautilus_list_view_new (NautilusWindowSlot *slot)
                           "window-slot", slot,
                           NULL);
  }
@@ -73,10 +73,22 @@ Index: nautilus-40.2/src/nautilus-list-view.c
 +{
 +  return list_view->details->tree_view;
 +}
-Index: nautilus-40.2/src/nautilus-window-slot.c
+Index: nautilus-42.0/src/nautilus-list-view.h
 ===================================================================
---- nautilus-40.2.orig/src/nautilus-window-slot.c
-+++ nautilus-40.2/src/nautilus-window-slot.c
+--- nautilus-42.0.orig/src/nautilus-list-view.h
++++ nautilus-42.0/src/nautilus-list-view.h
+@@ -37,4 +37,5 @@ struct _NautilusListView
+ 	NautilusListViewDetails *details;
+ };
+ 
+-NautilusFilesView * nautilus_list_view_new (NautilusWindowSlot *slot);
+\ No newline at end of file
++NautilusFilesView * nautilus_list_view_new (NautilusWindowSlot *slot);
++GtkTreeView * nautilus_list_view_get_tree_view (NautilusListView *list_view);
+Index: nautilus-42.0/src/nautilus-window-slot.c
+===================================================================
+--- nautilus-42.0.orig/src/nautilus-window-slot.c
++++ nautilus-42.0/src/nautilus-window-slot.c
 @@ -23,6 +23,9 @@
  
  #include "nautilus-window-slot.h"
@@ -87,9 +99,9 @@ Index: nautilus-40.2/src/nautilus-window-slot.c
  #include "nautilus-application.h"
  #include "nautilus-bookmark.h"
  #include "nautilus-bookmark-list.h"
-@@ -128,6 +131,17 @@ typedef struct
-     gboolean tried_mount;
+@@ -133,6 +136,17 @@ struct _NautilusWindowSlot
      gint view_mode_before_search;
+     gint view_mode_before_places;
  
 +    /* Interactive search */
 +    gboolean      isearch_enable;
@@ -105,8 +117,8 @@ Index: nautilus-40.2/src/nautilus-window-slot.c
      /* Menus */
      GMenuModel *extensions_background_menu;
      GMenuModel *templates_menu;
-@@ -249,6 +263,98 @@ nautilus_window_slot_get_navigation_stat
-     return data;
+@@ -607,6 +621,98 @@ nautilus_window_slot_search (NautilusWindowSlot *self,
+     }
  }
  
 +
@@ -202,19 +214,21 @@ Index: nautilus-40.2/src/nautilus-window-slot.c
 +
 +
  gboolean
- nautilus_window_slot_handles_location (NautilusWindowSlot *self,
-                                        GFile              *location)
-@@ -688,15 +794,70 @@ nautilus_window_slot_handle_event (Nauti
+ nautilus_window_slot_handle_event (NautilusWindowSlot    *self,
+                                    GtkEventControllerKey *controller,
+@@ -638,18 +744,63 @@ nautilus_window_slot_handle_event (NautilusWindowSlot    *self,
          }
      }
  
 -    /* If the action is not enabled, don't try to handle search */
 -    if (g_action_get_enabled (action))
 -    {
--        retval = nautilus_query_editor_handle_event (priv->query_editor, event);
+-        retval = nautilus_query_editor_handle_event (self->query_editor,
+-                                                     controller,
+-                                                     keyval,
+-                                                     state);
 -    }
-+    if (priv->isearch_enable) {
-+        GdkEvent    *new_event;
++    if (self->isearch_enable) {
 +        gchar       *old_text;
 +        const gchar *new_text;
 +        GdkScreen   *screen;
@@ -224,53 +238,47 @@ Index: nautilus-40.2/src/nautilus-window-slot.c
 +        isearch_ensure (self);
 +
 +        /* Make a copy of the current text */
-+        old_text = g_strdup (gtk_entry_get_text (GTK_ENTRY (priv->isearch_entry)));
-+        new_event = gdk_event_copy ((GdkEvent *) event);
-+        g_object_unref (((GdkEventKey *) new_event)->window);
++        old_text = g_strdup (gtk_entry_get_text (GTK_ENTRY (self->isearch_entry)));
++        gtk_widget_realize (self->isearch_window);
 +
-+        ((GdkEventKey *) new_event)->window =
-+                g_object_ref (gtk_widget_get_window (priv->isearch_window));
-+        gtk_widget_realize (priv->isearch_window);
-+
-+        popup_menu_id = g_signal_connect (priv->isearch_entry,
++        popup_menu_id = g_signal_connect (self->isearch_entry,
 +                                          "popup-menu", G_CALLBACK (gtk_true),
 +                                          NULL);
 +
 +        /* Move the entry off screen */
 +        screen = gtk_widget_get_screen (GTK_WIDGET (self));
-+        gtk_window_move (GTK_WINDOW (priv->isearch_window),
++        gtk_window_move (GTK_WINDOW (self->isearch_window),
 +                         gdk_screen_get_width (screen) + 1,
 +                         gdk_screen_get_height (screen) + 1);
-+        gtk_widget_show (priv->isearch_window);
++        gtk_widget_show (self->isearch_window);
 +
 +        /* Send the event to the window.  If the preedit_changed signal is emitted during this
-+         * event, we will set priv->imcontext_changed  */
-+        priv->isearch_imcontext_changed = FALSE;
-+        retval = gtk_widget_event (priv->isearch_window, new_event);
-+        gdk_event_free (new_event);
-+        gtk_widget_hide (priv->isearch_window);
++         * event, we will set self->imcontext_changed  */
++        self->isearch_imcontext_changed = FALSE;
++        retval = gtk_event_controller_key_forward (controller, self->isearch_window);
++        gtk_widget_hide (self->isearch_window);
 +
-+        g_signal_handler_disconnect (priv->isearch_entry, popup_menu_id);
++        g_signal_handler_disconnect (self->isearch_entry, popup_menu_id);
 +
 +        /* We check to make sure that the entry tried to handle the text, and that the text has
 +         * changed. */
-+        new_text = gtk_entry_get_text (GTK_ENTRY (priv->isearch_entry));
++        new_text = gtk_entry_get_text (GTK_ENTRY (self->isearch_entry));
 +        text_modified = strcmp (old_text, new_text) != 0;
 +        g_free (old_text);
 +
-+        if (priv->isearch_imcontext_changed || (retval && text_modified)) {
-+            if (isearch_start (self, gdk_event_get_device ((GdkEvent *) event))) {
++        if (self->isearch_imcontext_changed || (retval && text_modified)) {
++            if (isearch_start (self, gtk_get_current_event_device ())) {
 +                gtk_widget_grab_focus (GTK_WIDGET (self));
 +                return TRUE;
 +            }
-+            gtk_entry_set_text (GTK_ENTRY (priv->isearch_entry), "");
++            gtk_entry_set_text (GTK_ENTRY (self->isearch_entry), "");
 +            return FALSE;
 +        }
 +    } else {
 +        /* If the action is not enabled, don't try to handle search */
 +        if (g_action_get_enabled (action))
 +        {
-+            retval = nautilus_query_editor_handle_event (priv->query_editor, event);
++            retval = nautilus_query_editor_handle_event (self->query_editor, controller, keyval, state);
 +        }
  
 -    if (retval)
@@ -283,11 +291,11 @@ Index: nautilus-40.2/src/nautilus-window-slot.c
      }
  
      return retval;
-@@ -1250,6 +1411,14 @@ nautilus_window_slot_init (NautilusWindo
-     nautilus_application_set_accelerator (app, "slot.files-view-mode(uint32 0)", "<control>2");
-     nautilus_application_set_accelerator (app, "slot.search-visible", "<control>f");
+@@ -1151,6 +1302,14 @@ nautilus_window_slot_init (NautilusWindowSlot *self)
+                                           "<control>2");
+     nautilus_application_set_accelerators (app, "slot.search-visible", search_visible_accels);
  
-+    priv->isearch_enable = g_settings_get_boolean (nautilus_preferences,
++    self->isearch_enable = g_settings_get_boolean (nautilus_preferences,
 +                                                   NAUTILUS_PREFERENCES_ENABLE_INTERACTIVE_SEARCH);
 +
 +    g_signal_connect_swapped (nautilus_preferences,
@@ -295,45 +303,47 @@ Index: nautilus-40.2/src/nautilus-window-slot.c
 +                              G_CALLBACK (isearch_enable_changed),
 +                              self);
 +
-     priv->view_mode_before_search = NAUTILUS_VIEW_INVALID_ID;
+     self->view_mode_before_search = NAUTILUS_VIEW_INVALID_ID;
  }
  
-@@ -3103,6 +3272,7 @@ nautilus_window_slot_dispose (GObject *o
- 
+@@ -2905,6 +3064,8 @@ nautilus_window_slot_dispose (GObject *object)
+ {
+     NautilusWindowSlot *self;
      self = NAUTILUS_WINDOW_SLOT (object);
-     priv = nautilus_window_slot_get_instance_private (self);
 +    isearch_dispose (self);
- 
++
      g_signal_handlers_disconnect_by_data (nautilus_trash_monitor_get (), self);
  
-@@ -3166,6 +3336,10 @@ nautilus_window_slot_finalize (GObject *
+     g_signal_handlers_disconnect_by_data (nautilus_preferences, self);
+@@ -2963,6 +3124,11 @@ nautilus_window_slot_finalize (GObject *object)
+ {
+     NautilusWindowSlot *self;
      self = NAUTILUS_WINDOW_SLOT (object);
-     priv = nautilus_window_slot_get_instance_private (self);
- 
++
 +    g_signal_handlers_disconnect_by_func (nautilus_preferences,
 +                                        isearch_enable_changed,
 +                                        self);
 +
-     g_clear_pointer (&priv->title, g_free);
+     g_clear_pointer (&self->title, g_free);
  
      G_OBJECT_CLASS (nautilus_window_slot_parent_class)->finalize (object);
-@@ -3691,6 +3865,13 @@ nautilus_window_slot_set_active (Nautilu
+@@ -3417,6 +3583,13 @@ nautilus_window_slot_set_active (NautilusWindowSlot *self,
              window = nautilus_window_slot_get_window (self);
              g_assert (self == nautilus_window_get_active_slot (window));
  
 +            isearch_hide (self, NULL);
-+            if (priv->isearch_configure_event_id != 0) {
-+                g_signal_handler_disconnect (GTK_WIDGET (priv->window),
-+                                            priv->isearch_configure_event_id);
-+                priv->isearch_configure_event_id = 0;
++            if (self->isearch_configure_event_id != 0) {
++                g_signal_handler_disconnect (GTK_WIDGET (self->window),
++                                            self->isearch_configure_event_id);
++                self->isearch_configure_event_id = 0;
 +            }
 +
              gtk_widget_insert_action_group (GTK_WIDGET (window), "slot", NULL);
          }
  
-@@ -3770,3 +3951,792 @@ nautilus_window_slot_open_location_set_n
-     begin_location_change (self, location, NULL, new_selection,
-                            change_type, distance, NULL);
+@@ -3450,3 +3623,730 @@ nautilus_window_slot_get_query_editor (NautilusWindowSlot *self)
+ 
+     return self->query_editor;
  }
 +
 +/* Interactive search */
@@ -344,50 +354,47 @@ Index: nautilus-40.2/src/nautilus-window-slot.c
 +  GtkWidget                 *vbox;
 +  GtkWidget                 *toplevel;
 +  GdkScreen                 *screen;
-+  NautilusWindowSlotPrivate *priv;
-+
-+  priv = nautilus_window_slot_get_instance_private (slot);
 +
 +  toplevel = gtk_widget_get_toplevel (GTK_WIDGET (slot));
 +  screen = gtk_widget_get_screen (GTK_WIDGET (slot));
 +
-+  if (priv->isearch_window != NULL)
++  if (slot->isearch_window != NULL)
 +  {
 +    if (gtk_window_has_group (GTK_WINDOW (toplevel)))
 +      gtk_window_group_add_window (gtk_window_get_group (GTK_WINDOW (toplevel)),
-+                                   GTK_WINDOW (priv->isearch_window));
-+    else if (gtk_window_has_group (GTK_WINDOW (priv->isearch_window)))
++                                   GTK_WINDOW (slot->isearch_window));
++    else if (gtk_window_has_group (GTK_WINDOW (slot->isearch_window)))
 +      gtk_window_group_remove_window (gtk_window_get_group (
-+                                          GTK_WINDOW (priv->isearch_window)),
-+                                      GTK_WINDOW (priv->isearch_window));
++                                          GTK_WINDOW (slot->isearch_window)),
++                                      GTK_WINDOW (slot->isearch_window));
 +
-+    gtk_window_set_screen (GTK_WINDOW (priv->isearch_window), screen);
++    gtk_window_set_screen (GTK_WINDOW (slot->isearch_window), screen);
 +    return;
 +  }
 +
-+  priv->isearch_window = gtk_window_new (GTK_WINDOW_POPUP);
-+  gtk_window_set_screen (GTK_WINDOW (priv->isearch_window), screen);
++  slot->isearch_window = gtk_window_new (GTK_WINDOW_POPUP);
++  gtk_window_set_screen (GTK_WINDOW (slot->isearch_window), screen);
 +
 +  if (gtk_window_has_group (GTK_WINDOW (toplevel)))
 +    gtk_window_group_add_window (gtk_window_get_group (GTK_WINDOW (toplevel)),
-+                                 GTK_WINDOW (priv->isearch_window));
++                                 GTK_WINDOW (slot->isearch_window));
 +
-+  gtk_window_set_type_hint (GTK_WINDOW (priv->isearch_window),
++  gtk_window_set_type_hint (GTK_WINDOW (slot->isearch_window),
 +                            GDK_WINDOW_TYPE_HINT_UTILITY);
-+  gtk_window_set_modal (GTK_WINDOW (priv->isearch_window), TRUE);
-+  g_signal_connect (priv->isearch_window, "delete-event",
++  gtk_window_set_modal (GTK_WINDOW (slot->isearch_window), TRUE);
++  g_signal_connect (slot->isearch_window, "delete-event",
 +                    G_CALLBACK (isearch_window_delete_event), slot);
-+  g_signal_connect (priv->isearch_window, "key-press-event",
++  g_signal_connect (slot->isearch_window, "key-press-event",
 +                    G_CALLBACK (isearch_window_key_press_event), slot);
-+  g_signal_connect (priv->isearch_window, "button-press-event",
++  g_signal_connect (slot->isearch_window, "button-press-event",
 +                    G_CALLBACK (isearch_window_button_press_event), slot);
-+  g_signal_connect (priv->isearch_window, "scroll-event",
++  g_signal_connect (slot->isearch_window, "scroll-event",
 +                    G_CALLBACK (isearch_window_scroll_event), slot);
 +
 +  frame = gtk_frame_new (NULL);
 +  gtk_frame_set_shadow_type (GTK_FRAME (frame), GTK_SHADOW_ETCHED_IN);
 +  gtk_widget_show (frame);
-+  gtk_container_add (GTK_CONTAINER (priv->isearch_window), frame);
++  gtk_container_add (GTK_CONTAINER (slot->isearch_window), frame);
 +
 +  vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 0);
 +  gtk_widget_show (vbox);
@@ -395,18 +402,18 @@ Index: nautilus-40.2/src/nautilus-window-slot.c
 +  gtk_container_set_border_width (GTK_CONTAINER (vbox), 3);
 +
 +  /* add entry */
-+  priv->isearch_entry = gtk_entry_new ();
-+  gtk_widget_show (priv->isearch_entry);
-+  g_signal_connect (priv->isearch_entry, "populate-popup",
++  slot->isearch_entry = gtk_entry_new ();
++  gtk_widget_show (slot->isearch_entry);
++  g_signal_connect (slot->isearch_entry, "populate-popup",
 +                    G_CALLBACK (isearch_disable_hide), slot);
-+  g_signal_connect (priv->isearch_entry, "activate",
++  g_signal_connect (slot->isearch_entry, "activate",
 +                    G_CALLBACK (isearch_activate_event), slot);
 +
-+  g_signal_connect (G_OBJECT (priv->isearch_entry), "preedit-changed",
++  g_signal_connect (G_OBJECT (slot->isearch_entry), "preedit-changed",
 +                    G_CALLBACK (isearch_preedit_changed), slot);
-+  gtk_container_add (GTK_CONTAINER (vbox), priv->isearch_entry);
++  gtk_container_add (GTK_CONTAINER (vbox), slot->isearch_entry);
 +
-+  gtk_widget_realize (priv->isearch_entry);
++  gtk_widget_realize (slot->isearch_entry);
 +}
 +
 +static gboolean
@@ -424,23 +431,17 @@ Index: nautilus-40.2/src/nautilus-window-slot.c
 +isearch_timeout_destroy (gpointer user_data)
 +{
 +  NautilusWindowSlot        *slot = NAUTILUS_WINDOW_SLOT (user_data);
-+  NautilusWindowSlotPrivate *priv;
-+
-+  priv = nautilus_window_slot_get_instance_private (slot);
-+  priv->isearch_timeout_id = 0;
++  slot->isearch_timeout_id = 0;
 +}
 +
 +static void
 +isearch_timeout_restart (NautilusWindowSlot *slot)
 +{
-+  NautilusWindowSlotPrivate *priv;
-+
-+  priv = nautilus_window_slot_get_instance_private (slot);
-+  if (priv->isearch_timeout_id != 0)
++  if (slot->isearch_timeout_id != 0)
 +  {
-+    g_source_remove (priv->isearch_timeout_id);
++    g_source_remove (slot->isearch_timeout_id);
 +
-+    priv->isearch_timeout_id =
++    slot->isearch_timeout_id =
 +        gdk_threads_add_timeout_full (G_PRIORITY_LOW, ISEARCH_TIMEOUT,
 +                                      isearch_timeout, slot,
 +                                      isearch_timeout_destroy);
@@ -464,9 +465,6 @@ Index: nautilus-40.2/src/nautilus-window-slot.c
 +                                   NautilusWindowSlot *slot)
 +{
 +  GdkDevice                 *keyb_device;
-+  NautilusWindowSlotPrivate *priv;
-+
-+  priv = nautilus_window_slot_get_instance_private (slot);
 +
 +  g_return_val_if_fail (GTK_IS_WIDGET (widget), FALSE);
 +
@@ -474,10 +472,10 @@ Index: nautilus-40.2/src/nautilus-window-slot.c
 +  isearch_hide (slot, keyb_device);
 +
 +  /* A bit of hackery here */
-+  if (NAUTILUS_IS_CANVAS_VIEW (priv->content_view))
++  if (NAUTILUS_IS_CANVAS_VIEW (slot->content_view))
 +  {
 +    NautilusCanvasContainer *cc = nautilus_canvas_view_get_canvas_container (
-+        NAUTILUS_CANVAS_VIEW (priv->content_view));
++        NAUTILUS_CANVAS_VIEW (slot->content_view));
 +    gboolean retval = FALSE;
 +
 +    if (event->window == gtk_layout_get_bin_window (GTK_LAYOUT (cc)))
@@ -486,12 +484,12 @@ Index: nautilus-40.2/src/nautilus-window-slot.c
 +
 +    return retval;
 +  }
-+  else if (NAUTILUS_IS_LIST_VIEW (priv->content_view))
++  else if (NAUTILUS_IS_LIST_VIEW (slot->content_view))
 +  {
 +    gboolean          retval = FALSE;
-+    // NautilusListView *lv = NAUTILUS_LIST_VIEW (priv->content_view);
++    // NautilusListView *lv = NAUTILUS_LIST_VIEW (slot->content_view);
 +    GtkTreeView      *tv =
-+        nautilus_list_view_get_tree_view (NAUTILUS_LIST_VIEW (priv->content_view));
++        nautilus_list_view_get_tree_view (NAUTILUS_LIST_VIEW (slot->content_view));
 +
 +    if (event->window == gtk_tree_view_get_bin_window (tv))
 +      g_signal_emit_by_name (GTK_WIDGET (tv),
@@ -533,14 +531,10 @@ Index: nautilus-40.2/src/nautilus-window-slot.c
 +isearch_activate_items_alternate (NautilusWindowSlot *slot)
 +{
 +  GList                     *file_list;
-+  NautilusWindowSlotPrivate *priv;
-+
-+  priv = nautilus_window_slot_get_instance_private (slot);
-+
-+  file_list = nautilus_view_get_selection (priv->content_view);
-+  nautilus_files_view_activate_files (NAUTILUS_FILES_VIEW (priv->content_view),
++  file_list = nautilus_view_get_selection (slot->content_view);
++  nautilus_files_view_activate_files (NAUTILUS_FILES_VIEW (slot->content_view),
 +                                      file_list,
-+                                      NAUTILUS_WINDOW_OPEN_FLAG_NEW_TAB, TRUE);
++                                      NAUTILUS_OPEN_FLAG_NEW_TAB, TRUE);
 +  nautilus_file_list_free (file_list);
 +}
 +
@@ -622,11 +616,8 @@ Index: nautilus-40.2/src/nautilus-window-slot.c
 +                      gpointer  data)
 +{
 +  NautilusWindowSlot        *slot = NAUTILUS_WINDOW_SLOT (data);
-+  NautilusWindowSlotPrivate *priv;
 +
-+  priv = nautilus_window_slot_get_instance_private (slot);
-+
-+  priv->isearch_disable_hide = 1;
++  slot->isearch_disable_hide = 1;
 +  g_signal_connect (menu, "hide", G_CALLBACK (isearch_enable_hide), data);
 +}
 +
@@ -635,10 +626,7 @@ Index: nautilus-40.2/src/nautilus-window-slot.c
 +                         gchar              *preedit,
 +                         NautilusWindowSlot *slot)
 +{
-+  NautilusWindowSlotPrivate *priv;
-+
-+  priv = nautilus_window_slot_get_instance_private (slot);
-+  priv->isearch_imcontext_changed = 1;
++  slot->isearch_imcontext_changed = 1;
 +  isearch_timeout_restart (slot);
 +}
 +
@@ -647,22 +635,16 @@ Index: nautilus-40.2/src/nautilus-window-slot.c
 +                        NautilusWindowSlot *slot)
 +{
 +  // GtkTreePath               *path;
-+  NautilusWindowSlotPrivate *priv;
-+
-+  priv = nautilus_window_slot_get_instance_private (slot);
 +
 +  isearch_hide (slot, gtk_get_current_event_device ());
-+  nautilus_files_view_activate_selection (NAUTILUS_FILES_VIEW (priv->content_view));
++  nautilus_files_view_activate_selection (NAUTILUS_FILES_VIEW (slot->content_view));
 +}
 +
 +static gboolean
 +isearch_enable_hide_real (gpointer data)
 +{
 +  NautilusWindowSlot        *slot = NAUTILUS_WINDOW_SLOT (data);
-+  NautilusWindowSlotPrivate *priv;
-+
-+  priv = nautilus_window_slot_get_instance_private (slot);
-+  priv->isearch_disable_hide = 0;
++  slot->isearch_disable_hide = 0;
 +  return FALSE;
 +}
 +
@@ -731,34 +713,30 @@ Index: nautilus-40.2/src/nautilus-window-slot.c
 +isearch_hide (NautilusWindowSlot *slot,
 +              GdkDevice          *device)
 +{
-+  NautilusWindowSlotPrivate *priv;
-+
-+  priv = nautilus_window_slot_get_instance_private (slot);
-+
-+  if (priv->isearch_disable_hide)
++  if (slot->isearch_disable_hide)
 +    return;
 +
-+  if (!priv->isearch_enable)
++  if (!slot->isearch_enable)
 +    return;
 +
-+  if (priv->isearch_entry_changed_id)
++  if (slot->isearch_entry_changed_id)
 +  {
-+    g_signal_handler_disconnect (priv->isearch_entry,
-+                                 priv->isearch_entry_changed_id);
-+    priv->isearch_entry_changed_id = 0;
++    g_signal_handler_disconnect (slot->isearch_entry,
++                                 slot->isearch_entry_changed_id);
++    slot->isearch_entry_changed_id = 0;
 +  }
-+  if (priv->isearch_timeout_id)
++  if (slot->isearch_timeout_id)
 +  {
-+    g_source_remove (priv->isearch_timeout_id);
-+    priv->isearch_timeout_id = 0;
++    g_source_remove (slot->isearch_timeout_id);
++    slot->isearch_timeout_id = 0;
 +  }
-+  if (priv->isearch_window != NULL &&
-+      gtk_widget_get_visible (priv->isearch_window))
++  if (slot->isearch_window != NULL &&
++      gtk_widget_get_visible (slot->isearch_window))
 +  {
 +    /* send focus-in event */
-+    send_focus_change (GTK_WIDGET (priv->isearch_entry), device, FALSE);
-+    gtk_widget_hide (priv->isearch_window);
-+    gtk_entry_set_text (GTK_ENTRY (priv->isearch_entry), "");
++    send_focus_change (GTK_WIDGET (slot->isearch_entry), device, FALSE);
++    gtk_widget_hide (slot->isearch_window);
++    gtk_entry_set_text (GTK_ENTRY (slot->isearch_entry), "");
 +    send_focus_change (GTK_WIDGET (slot), device, TRUE);
 +  }
 +}
@@ -769,9 +747,6 @@ Index: nautilus-40.2/src/nautilus-window-slot.c
 +{
 +  // gint                       ret;
 +  const gchar               *text;
-+  NautilusWindowSlotPrivate *priv;
-+
-+  priv = nautilus_window_slot_get_instance_private (slot);
 +
 +  g_return_if_fail (GTK_IS_ENTRY (entry));
 +  g_return_if_fail (NAUTILUS_IS_WINDOW_SLOT (slot));
@@ -779,7 +754,7 @@ Index: nautilus-40.2/src/nautilus-window-slot.c
 +  text = gtk_entry_get_text (GTK_ENTRY (entry));
 +
 +  /* unselect all */
-+  nautilus_view_set_selection (priv->content_view, NULL);
++  nautilus_view_set_selection (slot->content_view, NULL);
 +
 +  isearch_timeout_restart (slot);
 +
@@ -796,47 +771,44 @@ Index: nautilus-40.2/src/nautilus-window-slot.c
 +  // GList *                    list;
 +  // gboolean                   found_focus = FALSE;
 +  GTypeClass                *klass;
-+  NautilusWindowSlotPrivate *priv;
 +
-+  priv = nautilus_window_slot_get_instance_private (slot);
-+
-+  if (!priv->isearch_enable)
++  if (!slot->isearch_enable)
 +    return FALSE;
 +
-+  if (priv->isearch_window != NULL &&
-+      gtk_widget_get_visible (priv->isearch_window))
++  if (slot->isearch_window != NULL &&
++      gtk_widget_get_visible (slot->isearch_window))
 +    return TRUE;
 +
-+  if (nautilus_files_view_get_loading (NAUTILUS_FILES_VIEW (priv->content_view)))
++  if (nautilus_files_view_get_loading (NAUTILUS_FILES_VIEW (slot->content_view)))
 +    return FALSE;
 +
 +  isearch_ensure (slot);
 +
 +  /* done, show it */
 +  isearch_position (slot);
-+  gtk_widget_show (priv->isearch_window);
++  gtk_widget_show (slot->isearch_window);
 +
-+  if (priv->isearch_entry_changed_id == 0)
++  if (slot->isearch_entry_changed_id == 0)
 +  {
-+    priv->isearch_entry_changed_id =
-+        g_signal_connect (priv->isearch_entry, "changed",
++    slot->isearch_entry_changed_id =
++        g_signal_connect (slot->isearch_entry, "changed",
 +                          G_CALLBACK (isearch_entry_changed), slot);
 +  }
 +
-+  priv->isearch_timeout_id =
++  slot->isearch_timeout_id =
 +      gdk_threads_add_timeout_full (G_PRIORITY_LOW, ISEARCH_TIMEOUT,
 +                                    isearch_timeout, slot,
 +                                    isearch_timeout_destroy);
 +
 +  /* Grab focus without selecting all the text. */
-+  klass = g_type_class_peek_parent (GTK_ENTRY_GET_CLASS (priv->isearch_entry));
-+  (*GTK_WIDGET_CLASS (klass)->grab_focus) (priv->isearch_entry);
++  klass = g_type_class_peek_parent (GTK_ENTRY_GET_CLASS (slot->isearch_entry));
++  (*GTK_WIDGET_CLASS (klass)->grab_focus) (slot->isearch_entry);
 +
 +  /* send focus-in event */
-+  send_focus_change (priv->isearch_entry, device, TRUE);
++  send_focus_change (slot->isearch_entry, device, TRUE);
 +
 +  /* search first matching iter */
-+  isearch_entry_changed (priv->isearch_entry, slot);
++  isearch_entry_changed (slot->isearch_entry, slot);
 +  return TRUE;
 +}
 +
@@ -851,19 +823,16 @@ Index: nautilus-40.2/src/nautilus-window-slot.c
 +  GtkRequisition             requisition;
 +  gint                       monitor_num;
 +  GdkRectangle               monitor;
-+  NautilusWindowSlotPrivate *priv;
-+
-+  priv = nautilus_window_slot_get_instance_private (slot);
 +
 +  monitor_num = gdk_screen_get_monitor_at_window (screen, window);
 +  gdk_screen_get_monitor_workarea (screen, monitor_num, &monitor);
 +
-+  gtk_widget_realize (priv->isearch_window);
++  gtk_widget_realize (slot->isearch_window);
 +
 +  gdk_window_get_origin (window, &window_x, &window_y);
 +  window_width = gdk_window_get_width (window);
 +  window_height = gdk_window_get_height (window);
-+  gtk_widget_get_preferred_size (priv->isearch_window, &requisition, NULL);
++  gtk_widget_get_preferred_size (slot->isearch_window, &requisition, NULL);
 +
 +  if (window_x + window_width > gdk_screen_get_width (screen))
 +    x = gdk_screen_get_width (screen) - requisition.width;
@@ -880,7 +849,7 @@ Index: nautilus-40.2/src/nautilus-window-slot.c
 +  else
 +    y = window_y + window_height;
 +
-+  gtk_window_move (GTK_WINDOW (priv->isearch_window), x, y);
++  gtk_window_move (GTK_WINDOW (slot->isearch_window), x, y);
 +}
 +
 +static gboolean
@@ -927,8 +896,7 @@ Index: nautilus-40.2/src/nautilus-window-slot.c
 +static GList *
 +isearch_get_sorted_files (NautilusWindowSlot *slot)
 +{
-+  NautilusWindowSlotPrivate *priv = nautilus_window_slot_get_instance_private (slot);
-+  NautilusView              *view = priv->content_view;
++  NautilusView              *view = slot->content_view;
 +  NautilusDirectory         *dir = nautilus_files_view_get_model (NAUTILUS_FILES_VIEW (view));
 +  GList                     *list = nautilus_directory_get_file_list (dir);
 +  GList                     *sorted_list;
@@ -970,11 +938,8 @@ Index: nautilus-40.2/src/nautilus-window-slot.c
 +  NautilusFile              *found = NULL;
 +  GList                     *current;
 +  GList                     *l;
-+  NautilusWindowSlotPrivate *priv;
 +
-+  priv = nautilus_window_slot_get_instance_private (slot);
-+
-+  current = g_list_find (files, priv->isearch_selected_file);
++  current = g_list_find (files, slot->isearch_selected_file);
 +  for (l = g_list_next (current); l; l = g_list_next (l))
 +  {
 +    NautilusFile *file = NAUTILUS_FILE (l->data);
@@ -1000,11 +965,8 @@ Index: nautilus-40.2/src/nautilus-window-slot.c
 +  NautilusFile              *found = NULL;
 +  GList                     *current;
 +  GList                     *l;
-+  NautilusWindowSlotPrivate *priv;
 +
-+  priv = nautilus_window_slot_get_instance_private (slot);
-+
-+  current = g_list_find (files, priv->isearch_selected_file);
++  current = g_list_find (files, slot->isearch_selected_file);
 +  for (l = g_list_previous (current); l; l = g_list_previous (l))
 +  {
 +    NautilusFile *file = NAUTILUS_FILE (l->data);
@@ -1027,11 +989,8 @@ Index: nautilus-40.2/src/nautilus-window-slot.c
 +{
 +  const gchar               *text;
 +  NautilusFile              *iter;
-+  NautilusWindowSlotPrivate *priv;
 +
-+  priv = nautilus_window_slot_get_instance_private (slot);
-+
-+  text = gtk_entry_get_text (GTK_ENTRY (priv->isearch_entry));
++  text = gtk_entry_get_text (GTK_ENTRY (slot->isearch_entry));
 +  iter = isearch_find_next (slot, text);
 +
 +  if (iter)
@@ -1045,11 +1004,8 @@ Index: nautilus-40.2/src/nautilus-window-slot.c
 +{
 +  const gchar               *text;
 +  NautilusFile              *iter;
-+  NautilusWindowSlotPrivate *priv;
 +
-+  priv = nautilus_window_slot_get_instance_private (slot);
-+
-+  text = gtk_entry_get_text (GTK_ENTRY (priv->isearch_entry));
++  text = gtk_entry_get_text (GTK_ENTRY (slot->isearch_entry));
 +  iter = isearch_find_prev (slot, text);
 +
 +  if (iter)
@@ -1063,13 +1019,11 @@ Index: nautilus-40.2/src/nautilus-window-slot.c
 +                       NautilusFile       *file)
 +{
 +  GList                     *list = NULL;
-+  NautilusWindowSlotPrivate *priv;
 +
 +  list = g_list_append (list, file);
-+  priv = nautilus_window_slot_get_instance_private (slot);
 +
-+  priv->isearch_selected_file = file;
-+  nautilus_view_set_selection (priv->content_view, list);
++  slot->isearch_selected_file = file;
++  nautilus_view_set_selection (slot->content_view, list);
 +  g_list_free (list);
 +}
 +
@@ -1078,61 +1032,43 @@ Index: nautilus-40.2/src/nautilus-window-slot.c
 +{
 +  NautilusWindowSlot        *slot;
 +  gboolean                   enable;
-+  NautilusWindowSlotPrivate *priv;
 +
 +  slot = NAUTILUS_WINDOW_SLOT (callback_data);
-+  priv = nautilus_window_slot_get_instance_private (slot);
 +
 +  enable =
 +      g_settings_get_boolean (nautilus_preferences,
 +                              NAUTILUS_PREFERENCES_ENABLE_INTERACTIVE_SEARCH);
 +
-+  if (enable != priv->isearch_enable)
++  if (enable != slot->isearch_enable)
 +  {
 +    if (!enable)
 +      isearch_dispose (slot);
 +
-+    priv->isearch_enable = enable;
++    slot->isearch_enable = enable;
 +  }
 +}
 +
 +static void
 +isearch_dispose (NautilusWindowSlot *slot)
 +{
-+  NautilusWindowSlotPrivate *priv;
-+
-+  priv = nautilus_window_slot_get_instance_private (slot);
-+
-+  if (!priv->isearch_enable)
++  if (!slot->isearch_enable)
 +    return;
 +
-+  if (priv->isearch_entry_changed_id != 0)
++  if (slot->isearch_entry_changed_id != 0)
 +  {
-+    g_signal_handler_disconnect (G_OBJECT (priv->isearch_entry),
-+                                 priv->isearch_entry_changed_id);
-+    priv->isearch_entry_changed_id = 0;
++    g_signal_handler_disconnect (G_OBJECT (slot->isearch_entry),
++                                 slot->isearch_entry_changed_id);
++    slot->isearch_entry_changed_id = 0;
 +  }
-+  if (priv->isearch_timeout_id != 0)
++  if (slot->isearch_timeout_id != 0)
 +  {
-+    g_source_remove (priv->isearch_timeout_id);
-+    priv->isearch_timeout_id = 0;
++    g_source_remove (slot->isearch_timeout_id);
++    slot->isearch_timeout_id = 0;
 +  }
-+  if (priv->isearch_window != NULL)
++  if (slot->isearch_window != NULL)
 +  {
-+    gtk_widget_destroy (priv->isearch_window);
-+    priv->isearch_window = NULL;
-+    priv->isearch_entry = NULL;
++    gtk_widget_destroy (slot->isearch_window);
++    slot->isearch_window = NULL;
++    slot->isearch_entry = NULL;
 +  }
 +}
-Index: nautilus-40.2/src/nautilus-list-view.h
-===================================================================
---- nautilus-40.2.orig/src/nautilus-list-view.h
-+++ nautilus-40.2/src/nautilus-list-view.h
-@@ -37,4 +37,5 @@ struct _NautilusListView
- 	NautilusListViewDetails *details;
- };
- 
--NautilusFilesView * nautilus_list_view_new (NautilusWindowSlot *slot);
-\ No newline at end of file
-+NautilusFilesView * nautilus_list_view_new (NautilusWindowSlot *slot);
-+GtkTreeView * nautilus_list_view_get_tree_view (NautilusListView *list_view);


### PR DESCRIPTION
Hey there :)
First of all thanks for keeping this vital feature alive! I ported the patch to the latest version of nautilus on ubuntu jammy (Nautilus 42.0).

The typeahead search was tested and no crashes were experienced so far, though the new version generates a lot of warnings, that some gdk functions are deprecated and will be removed soon.